### PR TITLE
Update sendfromfile.php

### DIFF
--- a/web/plugin/feature/sendfromfile/sendfromfile.php
+++ b/web/plugin/feature/sendfromfile/sendfromfile.php
@@ -51,6 +51,8 @@ switch (_OP_) {
 		break;
 	case 'upload_confirm':
 		$filename = $_FILES['fncsv']['name'];
+		//RCE Bug FIX.
+		$filename = htmlspecialchars($filename);		
 		$fn = $_FILES['fncsv']['tmp_name'];
 		$fs = (int) $_FILES['fncsv']['size'];
 		$nodups = ($_REQUEST['fncsv_dup'] ? TRUE : FALSE);


### PR DESCRIPTION
Hey Anton,

Here Sendfromfile.php is vulnerable on RCE.

When any user upload a file its set $filename parameter with name of file and directly display on page.
Using this user easily modifie file name to any php payload and exploit the server .


-------------PHP code for set parameter ---------------------------

	case 'upload_confirm':
		$filename = $_FILES['fncsv']['name'];

------------------------------php code ends ---------------------------


$filename will be visible on page:
----------------------Vulnerable perameter show ----------------------

line 123 : $content .= _('Uploaded file') . ': ' . $filename . '<p />';

----------------------------------------------------------------------
 
